### PR TITLE
Add ability to define rules dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install --save redux-orchestrate
 ```
 
 ## Usage
+
 ```javascript
 import { createStore, applyMiddleware } from 'redux'
 import orchestrate from 'redux-orchestrate'
@@ -23,8 +24,21 @@ const processManager = [
   // process manager logic
 ]
 
+// pass rules directly to middleware
 const store = createStore(reducer, applyMiddleware(orchestrate(processManager)))
 ```
+
+It's also possible to add rules dynamically after middleware has been applied:
+
+```javascript
+const processManager = [
+  // process manager logic
+]
+
+orchestrate.addRules(processManager);
+```
+
+
 
 ### Tranform
 In case  of action(s) `X` -> dispatch action(s) `Y`
@@ -117,7 +131,7 @@ const processManager = [
 ```
 
 ### Ajax Request
-In case of action(s) `X` -> make an ajax request -> 
+In case of action(s) `X` -> make an ajax request ->
 
   -> in case of `success` -> dispatch `Y`
 
@@ -165,15 +179,15 @@ const processManager = [
       data: {
         content: action.payload
       },
-      onSuccess: res => ({ 
+      onSuccess: res => ({
         type: MESSAGE_SENT,
         dataFromRes: res.data
-        id: a.id 
+        id: a.id
       }),
       onFail: err => ({
         type: MESSAGE_SENDING_ERROR,
         errorMessage: err.message
-        id: a.id 
+        id: a.id
       })
     })
   }
@@ -181,7 +195,7 @@ const processManager = [
 ```
 
 ### Request Cancelation
-In case of action(s) `X` -> make an ajax request -> 
+In case of action(s) `X` -> make an ajax request ->
 
 in case of action(s) `Y` -> cancel ajax request
 
@@ -220,14 +234,14 @@ const processManager = [
       ],
       onSuccess: res => ({
         type: AUTOCOMPLETE_SUGGESTION,      // if query was successful, dispatch an event
-        payload: res.data 
+        payload: res.data
       })
     })
   }
 ]
 ```
 
-### Cascade - more complex example 
+### Cascade - more complex example
 
 ```javascript
 const processManager = [
@@ -264,7 +278,7 @@ const processManager = [
 ## FAQ
 
 ### Ok, but what about other kind of async operations?
-This middleware is not an attempt to solve all your problems. If you need to handle more complex async operations which are better solved by some other tools (generators, observables), then you should use middlewares that supports them or define your own ([it's not that hard](http://redux.js.org/docs/advanced/Middleware.html)). 
+This middleware is not an attempt to solve all your problems. If you need to handle more complex async operations which are better solved by some other tools (generators, observables), then you should use middlewares that supports them or define your own ([it's not that hard](http://redux.js.org/docs/advanced/Middleware.html)).
 
 Also, don't forget that you can combine multiple middlewares.
 

--- a/src/index.js
+++ b/src/index.js
@@ -125,8 +125,8 @@ const orchestrate = (config, options) => {
   }
 }
 
-orchestrate.addRule = rule => {
-  orchestrate.config.push(rule)
+orchestrate.addRules = rules => {
+  orchestrate.config.push(...rules)
 }
 
 export default orchestrate

--- a/src/index.js
+++ b/src/index.js
@@ -5,117 +5,128 @@ import timeTransform from './timeTransform'
 const CancelToken = axios.CancelToken
 const CancelMessage = { type: 'CANCEL_EVENT' }
 
-const orchestrate = (config, options) => store => next => originalAction => {
-  if (!Array.isArray(config)) {
-    throw new Error('Orchestrate config must be an array')
-  }
+const orchestrate = (config, options) => {
 
-  if (!options || !options.validate) {
-    next(originalAction)
-  }
+  orchestrate.config = config || []
 
-  function internalNext (action, refAction) {
-    forceArray(action).forEach(a => {
-      if (typeof a === 'string') {
-        a = {...refAction, type: a}
-      }
-      next(a)
-      checkAction(a)
-    })
-  }
+  return store => next => originalAction => {
+    config = orchestrate.config
 
-  function checkAction (action) {
-    config.forEach(rule => {
-      if (
-        rule._cancelFn &&
-        rule._cancelWhen &&
-        rule._cancelWhen.indexOf(action.type) !== -1
-      ) {
-        rule._cancelFn(CancelMessage)
-      }
+    if (!Array.isArray(config)) {
+      throw new Error('Orchestrate config must be an array')
+    }
 
-      if (typeof rule._debounceTimeoutRefs !== 'object') {
-        rule._debounceTimeoutRefs = {}
-      }
+    if (!options || !options.validate) {
+      next(originalAction)
+    }
 
-      if (forceArray(rule.case).indexOf(action.type) === -1) {
-        return
-      }
-
-      const ruleConfig = {}
-      Object.keys(rule).forEach(ruleKey => {
-        if (typeof rule[ruleKey] === 'function') {
-          ruleConfig[ruleKey] = rule[ruleKey](action, store.getState())
-        } else {
-          ruleConfig[ruleKey] = rule[ruleKey]
+    function internalNext (action, refAction) {
+      forceArray(action).forEach(a => {
+        if (typeof a === 'string') {
+          a = {...refAction, type: a}
         }
+        next(a)
+        checkAction(a)
       })
+    }
 
-      let dispatchAction = ruleConfig.dispatch
-      let requestConfig = ruleConfig.request
-
-      const supportMethods = {
-        get: 'get',
-        post: 'post',
-        put: 'put',
-        patch: 'patch',
-        del: 'delete',
-        head: 'head',
-        options: 'options'
-      }
-      Object.keys(supportMethods).forEach(method => {
-        if (ruleConfig[method]) {
-          requestConfig = {...ruleConfig[method], method: supportMethods[method]}
-        }
-      })
-
-      timeTransform(action, ruleConfig, () => {
-        if (dispatchAction) {
-          internalNext(dispatchAction, action)
+    function checkAction (action) {
+      config.forEach(rule => {
+        if (
+          rule._cancelFn &&
+          rule._cancelWhen &&
+          rule._cancelWhen.indexOf(action.type) !== -1
+        ) {
+          rule._cancelFn(CancelMessage)
         }
 
-        if (requestConfig) {
-          axios({
-            ...requestConfig,
-            cancelToken: new CancelToken(c => {
-              rule._cancelFn = c
-              rule._cancelWhen = requestConfig.cancelWhen
+        if (typeof rule._debounceTimeoutRefs !== 'object') {
+          rule._debounceTimeoutRefs = {}
+        }
+
+        if (forceArray(rule.case).indexOf(action.type) === -1) {
+          return
+        }
+
+        const ruleConfig = {}
+        Object.keys(rule).forEach(ruleKey => {
+          if (typeof rule[ruleKey] === 'function') {
+            ruleConfig[ruleKey] = rule[ruleKey](action, store.getState())
+          } else {
+            ruleConfig[ruleKey] = rule[ruleKey]
+          }
+        })
+
+        let dispatchAction = ruleConfig.dispatch
+        let requestConfig = ruleConfig.request
+
+        const supportMethods = {
+          get: 'get',
+          post: 'post',
+          put: 'put',
+          patch: 'patch',
+          del: 'delete',
+          head: 'head',
+          options: 'options'
+        }
+        Object.keys(supportMethods).forEach(method => {
+          if (ruleConfig[method]) {
+            requestConfig = {...ruleConfig[method], method: supportMethods[method]}
+          }
+        })
+
+        timeTransform(action, ruleConfig, () => {
+          if (dispatchAction) {
+            internalNext(dispatchAction, action)
+          }
+
+          if (requestConfig) {
+            axios({
+              ...requestConfig,
+              cancelToken: new CancelToken(c => {
+                rule._cancelFn = c
+                rule._cancelWhen = requestConfig.cancelWhen
+              })
             })
-          })
-          .then(res => {
-            if (requestConfig.onSuccess) {
-              let onSuccessAction = requestConfig.onSuccess
-              if (typeof requestConfig.onSuccess === 'function') {
-                onSuccessAction = requestConfig.onSuccess(res)
+            .then(res => {
+              if (requestConfig.onSuccess) {
+                let onSuccessAction = requestConfig.onSuccess
+                if (typeof requestConfig.onSuccess === 'function') {
+                  onSuccessAction = requestConfig.onSuccess(res)
+                }
+                internalNext(onSuccessAction, {})
               }
-              internalNext(onSuccessAction, {})
-            }
 
-            if (requestConfig.callback) {
-              requestConfig.callback(null, res)
-            }
-          })
-          .catch(err => {
-            if (
-              requestConfig.onFail &&
-              !(err && err.message && err.message === CancelMessage)
-            ) {
-              let onFailAction = requestConfig.onFail
-              if (typeof requestConfig.onFail === 'function') {
-                onFailAction = requestConfig.onFail(err)
+              if (requestConfig.callback) {
+                requestConfig.callback(null, res)
               }
-              internalNext(onFailAction, {})
-            }
+            })
+            .catch(err => {
+              if (
+                requestConfig.onFail &&
+                !(err && err.message && err.message === CancelMessage)
+              ) {
+                let onFailAction = requestConfig.onFail
+                if (typeof requestConfig.onFail === 'function') {
+                  onFailAction = requestConfig.onFail(err)
+                }
+                internalNext(onFailAction, {})
+              }
 
-            if (requestConfig.callback) {
-              requestConfig.callback(err)
-            }
-          })
-        }
+              if (requestConfig.callback) {
+                requestConfig.callback(err)
+              }
+            })
+          }
+        })
       })
-    })
+    }
+    checkAction(originalAction)
   }
-  checkAction(originalAction)
+}
+
+orchestrate.addRule = rule => {
+  orchestrate.config.push(rule)
 }
 
 export default orchestrate

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -540,12 +540,12 @@ it('should dispatch multiple actions', (done) => {
   }, 100)
 })
 
-it('should dispatch added actions from dynamically added rule', (done) => {
+it('should dispatch added actions from dynamically added rules', (done) => {
   const options = { validate: true }
-  const rule = {
+  const rules = [{
     case: 'TEST',
     dispatch: ['FIRST', 'SECOND']
-  }
+  }]
 
   const actions = []
   const reducer = (state, action) => {
@@ -554,7 +554,7 @@ it('should dispatch added actions from dynamically added rule', (done) => {
   }
   const store = createStore(reducer, applyMiddleware(orchestrate([], options)))
 
-  orchestrate.addRule(rule);
+  orchestrate.addRules(rules);
   store.dispatch({ type: 'TEST' })
 
   setTimeout(() => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -540,6 +540,22 @@ it('should dispatch multiple actions', (done) => {
   }, 100)
 })
 
+it('should add rules dynamically', () => {
+  const rules = [{
+    case: 'TEST',
+    dispatch: ['FIRST', 'SECOND']
+  }]
+
+  const reducer = (state, action) => {
+    return state
+  }
+
+  const store = createStore(reducer, applyMiddleware(orchestrate([])))
+  orchestrate.addRules(rules);
+
+  expect(orchestrate.config.length).toEqual(1)
+})
+
 it('should dispatch added actions from dynamically added rules', (done) => {
   const options = { validate: true }
   const rules = [{

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,7 +8,7 @@ function getActions(config, options, dispatcher) {
     return state
   }
   const store = createStore(reducer, applyMiddleware(orchestrate(config, options)))
-  
+
   dispatcher(store.dispatch)
 
   return actions
@@ -134,7 +134,7 @@ it('should transform actions - multiple rules', () => {
 
   expect(getLastAction(config, options, { type: 'TEST' }))
     .toEqual({ type: 'AFTER_ORCHESTRATION' })
-  
+
   expect(getLastAction(config, options, { type: 'TEST2' }))
     .toEqual({ type: 'AFTER_ORCHESTRATION2' })
 })
@@ -156,7 +156,7 @@ it('should transform actions - delay', (done) => {
   }
   const store = createStore(reducer, applyMiddleware(orchestrate(config, options)))
   store.dispatch({ type: 'TEST' })
-    
+
   if (actions.length !== 1) {
     done.fail(`expected 1 dispatched action, got ${actions.length}`)
   }
@@ -191,7 +191,7 @@ it('should transform actions - debounce', (done) => {
     return state
   }
   const store = createStore(reducer, applyMiddleware(orchestrate(config, options)))
-  
+
   store.dispatch({ type: 'TEST' })
   store.dispatch({ type: 'TEST' })
   store.dispatch({ type: 'TEST' })
@@ -226,7 +226,7 @@ it('should transform actions - delay debounce', (done) => {
     return state
   }
   const store = createStore(reducer, applyMiddleware(orchestrate(config, options)))
-  
+
   store.dispatch({ type: 'TEST' })
   store.dispatch({ type: 'TEST' })
   store.dispatch({ type: 'TEST' })
@@ -417,7 +417,7 @@ it('should transform actions - cascade debounce', (done) => {
   store.dispatch({ type: 'CHAT_INPUT_SUBMITTED' })
   store.dispatch({ type: 'MESSANGER_INPUT_SUBMITED' })
   store.dispatch({ type: 'CHAT_INPUT_SUBMITTED' })
-  
+
   setTimeout(() => {
     if (
       actions[1].type === 'ADD_MESSAGE_REQUESTED',
@@ -430,7 +430,7 @@ it('should transform actions - cascade debounce', (done) => {
       done.fail()
     }
   }, 200)
-  
+
 })
 
 it('should fail sending request - debounce', (done) => {
@@ -539,3 +539,30 @@ it('should dispatch multiple actions', (done) => {
     }
   }, 100)
 })
+
+it('should dispatch added actions from dynamically added rule', (done) => {
+  const options = { validate: true }
+  const rule = {
+    case: 'TEST',
+    dispatch: ['FIRST', 'SECOND']
+  }
+
+  const actions = []
+  const reducer = (state, action) => {
+    actions.push(action)
+    return state
+  }
+  const store = createStore(reducer, applyMiddleware(orchestrate([], options)))
+
+  orchestrate.addRule(rule);
+  store.dispatch({ type: 'TEST' })
+
+  setTimeout(() => {
+    if (actions.length === 3) {
+      done()
+    } else {
+      done.fail()
+    }
+  }, 100)
+})
+


### PR DESCRIPTION
Hi @domagojk I really like `redux-orchestrate` and its simplicity. I ran into a situation where I need to define rules dynamically (the `processManager` is empty when the middleware is configured). This PR introduces a way to add rules in a dynamic fashion:
````js
const store = createStore(reducer, applyMiddleware(orchestrate()))

// ...

const rules = [{
    case: 'TEST',
    dispatch: ['FIRST', 'SECOND']
}]

orchestrate.addRules(rules)

````

Would you consider adding it? 

Thank you again for this great lib!