### PR TITLE
If rule.case is a function, evaluate it before check vs action.type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,10 +39,6 @@ const orchestrate = (config = [], options) => {
           rule._debounceTimeoutRefs = {}
         }
 
-        if (forceArray(rule.case).indexOf(action.type) === -1) {
-          return
-        }
-
         const ruleConfig = {}
         Object.keys(rule).forEach(ruleKey => {
           if (typeof rule[ruleKey] === 'function') {
@@ -51,6 +47,10 @@ const orchestrate = (config = [], options) => {
             ruleConfig[ruleKey] = rule[ruleKey]
           }
         })
+
+        if (forceArray(ruleConfig.case).indexOf(action.type) === -1) {
+          return
+        }
 
         let dispatchAction = ruleConfig.dispatch
         let requestConfig = ruleConfig.request


### PR DESCRIPTION
Hey there - I've just been playing around with redux-orchestrate and I noticed that despite the README suggesting it should work, having a functional `rule.case` _didn't_ actually do anything. The reason was that `rule.case` was being checked vs `action.start` _before_ any functions in `rule` were evaluated. Here's a fix that seems to work.

I'm afraid I haven't run any of your tests as I've been away from the JS world for a few years and I'm still finding my feet, infrastructure-wise, but my hope is that nothing's broken.

Thanks!